### PR TITLE
GERONIMO-6603: Change the inconsistent method name.

### DIFF
--- a/framework/buildsupport/car-maven-plugin/src/main/java/org/apache/geronimo/mavenplugins/car/AbstractCarMojo.java
+++ b/framework/buildsupport/car-maven-plugin/src/main/java/org/apache/geronimo/mavenplugins/car/AbstractCarMojo.java
@@ -1079,7 +1079,7 @@ public abstract class AbstractCarMojo
         }
     }
 
-    protected void listBundles(BundleContext ctx) {
+    protected void logBundles(BundleContext ctx) {
         StringBuilder b = new StringBuilder("Bundles:");
         for (Bundle bundle: ctx.getBundles()) {
             b.append("\n   Id:").append(bundle.getBundleId()).append("  status:").append(bundle.getState()).append("  ").append(bundle.getLocation());
@@ -1106,7 +1106,7 @@ public abstract class AbstractCarMojo
                 }
             }
         }
-        listBundles(ctx);
+        logBundles(ctx);
         throw new MojoExecutionException("Cant start all the bundles");
     }
 

--- a/framework/buildsupport/car-maven-plugin/src/main/java/org/apache/geronimo/mavenplugins/car/PackageMojo.java
+++ b/framework/buildsupport/car-maven-plugin/src/main/java/org/apache/geronimo/mavenplugins/car/PackageMojo.java
@@ -252,7 +252,7 @@ public class PackageMojo extends AbstractCarMojo {
             getLog().debug("Creating kernel...");
             bundleContext = getFramework().getBundleContext();
             waitForBundles(bundleContext, 20000l);
-            listBundles(bundleContext);
+            logBundles(bundleContext);
 
             getLog().debug("Starting configurations..." + Arrays.asList(deploymentConfigs));
 
@@ -311,7 +311,7 @@ public class PackageMojo extends AbstractCarMojo {
             invokeDeployer(deployer, null);
         } catch (Exception e) {
             getLog().info("Exception, use console to investigate ", e);
-            listBundles(bundleContext);
+            logBundles(bundleContext);
             PackageAdmin admin = (PackageAdmin) getService(bundleContext, PackageAdmin.class.getName(), null, 1000l);
 //            for (Bundle b : bundleContext.getBundles()) {
 //                int state = b.getState();
@@ -325,7 +325,7 @@ public class PackageMojo extends AbstractCarMojo {
 //                    }
 //                }
 //            }
-            listBundles(bundleContext);
+            logBundles(bundleContext);
             while (1 == 1) {
                 try {
                     Thread.sleep(1000L);


### PR DESCRIPTION
Change the method name 'listBundles' to 'logBundles'.
The method is named "listBundles".
"listBundles" seems that the method will return a list of bundles.
Actually, this method adds the bundles into the log info.
Thus, "logBundles" should be more intuitive than "listBundles".