### PR TITLE
GERONIMO-6721 Use Objects.equals(String,String) to avoid possible NullPointerException

### DIFF
--- a/plugins/console/console-base-portlets/src/main/java/org/apache/geronimo/console/webmanager/ConnectorPortlet.java
+++ b/plugins/console/console-base-portlets/src/main/java/org/apache/geronimo/console/webmanager/ConnectorPortlet.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
+
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -103,7 +105,7 @@ public class ConnectorPortlet extends BasePortlet {
             server = "unknown";
         }
         actionResponse.setRenderParameter(PARM_SERVER, server);
-        if(mode.equals("new")) {
+        if(Objects.equals(mode, "new")) {
             // User selected to add a new connector, need to show criteria portlet
             actionResponse.setRenderParameter(PARM_MODE, "new");
             String connectorType = actionRequest.getParameter(PARM_CONNECTOR_TYPE);


### PR DESCRIPTION
Hello,
I found that the String "mode" may cause potential risk of NullPointerException since the method "getParameter" may return a null value. One recommended API is Objects.equals(String,String) which can avoid this exception.